### PR TITLE
Updated hasHarness check

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -72,17 +72,16 @@ local function CinematicShow(bool)
     end
 end
 
-local function hasHarness(items)
+local function hasHarness()
     local ped = PlayerPedId()
     if not IsPedInAnyVehicle(ped, false) then return end
 
     local _harness = false
-    if items then 
-        for _, v in pairs(items) do
-            if v.name == 'harness' then
-                _harness = true
-            end
-        end
+    local hasHarness = exports['qb-smallresources']:HasHarness()
+    if hasHarness then
+        _harness = true
+    else
+        _harness = false
     end
 
     harness = _harness
@@ -1083,7 +1082,7 @@ CreateThread(function()
         if LocalPlayer.state.isLoggedIn then
             local ped = PlayerPedId()
             if IsPedInAnyVehicle(ped, false) then
-                hasHarness(PlayerData.items)
+                hasHarness()
             end
         end
     end


### PR DESCRIPTION
The current harness check only checks to see if you have a harness in your inventory and not actually attached.

This change will make it only show the icon if the harness has been used(attached) otherwise it's technically showing you have the harness but you don't have it attached, which kind of defeats the purpose of the icon.

Not sure if there is a better way of doing this, but it works and has been tested.
https://nooby.xyz/nooby/f/FcYqoL-05-06-2022.mp4 (Video showing it works)