### PR TITLE
Permit configure vehicle classes to not gain stress

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -254,7 +254,7 @@ RegisterNUICallback('openMenuSounds', function(data, cb)
         Menu.isOpenMenuSoundsChecked = true
     else
         Menu.isOpenMenuSoundsChecked = false
-    end 
+    end
     TriggerEvent("hud:client:playHudChecklistSound")
 end)
 
@@ -867,7 +867,7 @@ end
 
 CreateThread(function()
     local wasInVehicle = false
-    while true do        
+    while true do
         if LocalPlayer.state.isLoggedIn then
             Wait(500)
 
@@ -875,7 +875,7 @@ CreateThread(function()
             local player = PlayerPedId()
             local playerId = PlayerId()
             local weapon = GetSelectedPedWeapon(player)
-            
+
             -- Player hud
             if not IsWhitelistedWeaponArmed(weapon) then
                 -- weapon ~= 0 fixes unarmed on Offroad vehicle Blzer Aqua showing armed bug
@@ -893,13 +893,13 @@ CreateThread(function()
             if not IsEntityInWater(player) then
                 oxygen = 100 - GetPlayerSprintStaminaRemaining(playerId)
             end
-            
+
             -- Oxygen
             if IsEntityInWater(player) then
                 oxygen = GetPlayerUnderwaterTimeRemaining(playerId) * 10
             end
 
-            -- Voice setup            
+            -- Voice setup
             local talking = NetworkIsPlayerTalking(playerId)
             local voice = 0
             if LocalPlayer.state['proximity'] then
@@ -957,7 +957,7 @@ CreateThread(function()
                 end
 
                 wasInVehicle = true
-                
+
                 updatePlayerHud({
                     show,
                     GetEntityHealth(player) - 100,
@@ -1109,8 +1109,11 @@ CreateThread(function() -- Speeding
             if IsPedInAnyVehicle(ped, false) then
                 local speed = GetEntitySpeed(GetVehiclePedIsIn(ped, false)) * speedMultiplier
                 local stressSpeed = seatbeltOn and config.MinimumSpeed or config.MinimumSpeedUnbuckled
-                if speed >= stressSpeed then
-                    TriggerServerEvent('hud:server:GainStress', math.random(1, 3))
+                local vehClass = GetVehicleClass(GetVehiclePedIsIn(ped, false))
+                if Config.VehClassStress[tostring(vehClass)] then
+                    if speed >= stressSpeed then
+                        TriggerServerEvent('hud:server:GainStress', math.random(1, 3))
+                    end
                 end
             end
         end
@@ -1304,9 +1307,9 @@ CreateThread(function()
             else
                 heading = tostring(round(360.0 - GetEntityHeading(player)))
             end
-            
-            if heading == '360' then 
-                heading = '0' 
+
+            if heading == '360' then
+                heading = '0'
             end
 
             local playerInVehcile = IsPedInAnyVehicle(player)
@@ -1314,9 +1317,9 @@ CreateThread(function()
             if heading ~= lastHeading or lastInVehicle ~= playerInVehcile then
                 if playerInVehcile then
                     local crossroads = getCrossroads(player)
-                    SendNUIMessage ({ 
-                        action = 'update', 
-                        value = heading 
+                    SendNUIMessage ({
+                        action = 'update',
+                        value = heading
                     })
                     updateBaseplateHud({
                         show,
@@ -1330,9 +1333,9 @@ CreateThread(function()
                     lastInVehicle = true
                 else
                     if not Menu.isOutCompassChecked then
-                        SendNUIMessage ({ 
-                            action = 'update', 
-                            value = heading 
+                        SendNUIMessage ({
+                            action = 'update',
+                            value = heading
                         })
                         SendNUIMessage ({
                             action = 'baseplate',

--- a/config.lua
+++ b/config.lua
@@ -139,3 +139,27 @@ Config.FuelBlacklist = {
 	"khamelion",
 	"wheelchair",
 }
+
+Config.VehClassStress = { -- Enable/Disable gaining stress from vehicle classes in this table
+    ['0'] = true, -- Compacts
+    ['1'] = true, -- Sedans
+    ['2'] = true, -- SUVs
+    ['3'] = true, -- Coupes
+    ['4'] = true, -- Muscle
+    ['5'] = true,  -- Sports Classics
+    ['6'] = true, -- Sports
+    ['7'] = true, -- Super
+    ['8'] = false, -- Motorcycles
+    ['9'] = true, -- Off Road
+    ['10'] = true, -- Industrial
+    ['11'] = true,  -- Utility
+    ['12'] = true,  -- Vans
+    ['13'] = false, -- Cycles
+    ['14'] = false, -- Boats
+    ['15'] = false, -- Helicopters
+    ['16'] = false, -- Planes
+    ['18'] = false, -- Emergency
+    ['19'] = false, -- Military
+    ['20'] = false, -- Commercial
+    ['21'] = false  -- Trains
+}


### PR DESCRIPTION
This update lets we configure which vehicle classes would not trigger the gain stress feature, e.g: Helicopters, Planes, Bicycles, etc...